### PR TITLE
Set github_branch to trunk

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -133,7 +133,7 @@ github_project_repo = "https://github.com/orgs/atsign-foundation/projects/5"
 
 # Uncomment this if you have a newer GitHub repo with "main" as the default branch,
 # or specify a new value if you want to reference another branch in your GitHub links
-# github_branch= "main"
+github_branch= "trunk"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 # gcs_engine_id = "d72aa9b2712488cc3"


### PR DESCRIPTION
Fixes #33 

**- What I did**

Searched Docsy theme for `master`, and found `github_branch` setting need to be changed.

**- How I did it**

Set `github_branch= "trunk"` in `config.toml` 

**- How to verify it**

Browse to docs and click on "Edit this page"

**- Description for the changelog**

Set github_branch to trunk