### PR TITLE
Redirects for broken pub.dev links

### DIFF
--- a/content/en/docs/Functional_Architecture/libraries.md
+++ b/content/en/docs/Functional_Architecture/libraries.md
@@ -112,7 +112,7 @@ Provides methods to encode/decode strings to/from the utf7 format as defined in 
 
 ### at_contact
 
-A starting point for Dart libraries or applications.
+A Dart library for managing contact data that developers can use for their applications.
 
 [Learn more](https://pub.dev/packages/at_contact)
 

--- a/static/apidocs/index.html
+++ b/static/apidocs/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; URL='https://atsign.dev'" />

--- a/static/at_docs-dev_env/at_persistence_secondary_server/index.html
+++ b/static/at_docs-dev_env/at_persistence_secondary_server/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; URL='https://atsign.dev'" />


### PR DESCRIPTION
**- What I did**

Added redirects from broken links to atsign.dev root

**- How I did it**

```html
<meta http-equiv="refresh" content="0; URL='https://atsign.dev'" />
```

in a couple of static index.html files

**- How to verify it**

Click on:

https://atsign.dev/apidocs

and

https://atsign.dev/at_docs-dev_env/at_persistence_secondary_server/index.html

Once merged and released

**- Description for the changelog**

Redirects for broken pub.dev links