### PR TITLE
More specific link replacement for staging baseURL

### DIFF
--- a/.github/workflows/HugoBuild.yml
+++ b/.github/workflows/HugoBuild.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm ci
 
       - name: Set staging baseURL
-        run: sed -i s/atsign.dev/devstaging.atsign.wtf/ config.toml
+        run: sed -i s#https://atsign.dev#https://devstaging.atsign.wtf# config.toml
 
       - name: Build
         run: hugo --minify


### PR DESCRIPTION
Fixes #223

@murali-shris since you spotted the problem, can you please review this PR so that it can be fixed before the US wakes up. As it just affects staging we don't even need to do a release to prod.

**- What I did**

Tightened up the sed parameters so that only the `baseURL` is changed without affecting `github_repo` or blog `url`

**- How I did it**

Sed now targets the full baseURL rather than just atsign.dev

**- How to verify it**

Click on `Edit this page` button once this PR has been merged.

**- Description for the changelog**

More specific link replacement for staging baseURL