### PR TITLE
Fix a code snippet error in migration_uptake.md

### DIFF
--- a/content/en/docs/rSDK_migration/migration_uptake.md
+++ b/content/en/docs/rSDK_migration/migration_uptake.md
@@ -61,7 +61,7 @@ void _notificationCallBack(var response) {
 ```dart
 /// **SDK 3.X**
 
-atClient!.notificationService.subscribe(regex: 'wavi').listen(_notificationCallBack);
+atClientManager.notificationService.subscribe(regex: 'wavi').listen(_notificationCallBack);
 
 void _notificationCallBack(AtNotification atNotification) {
     var notificationKey = atNotification.key;


### PR DESCRIPTION
**- What I did**
I was trying to find out what "rSDK" meant; a google search pointed me to the rsdk_migration page on atsign.dev. I clicked through to the migration_uptake.md noticed a code snippet error

**- How I did it**
Changed
```atClient!.notificationService.subscribe(regex: 'wavi').listen(_notificationCallBack);```
to
```atClientManager.notificationService.subscribe(regex: 'wavi').listen(_notificationCallBack);```

**- How to verify it**

**- Description for the changelog**
Fixed an error in the "Starting listening to notifications" code snippet in migration_uptake.md
