### PR TITLE
Fixes #331

### DIFF
--- a/content/en/docs/Functional_Architecture/rSDK_migration/migration_uptake.md
+++ b/content/en/docs/Functional_Architecture/rSDK_migration/migration_uptake.md
@@ -61,7 +61,7 @@ void _notificationCallBack(var response) {
 ```dart
 /// **SDK 3.X**
 
-atClient!.notificationService.subscribe(regex: 'wavi').listen(_notificationCallBack);
+atClientManager.notificationService.subscribe(regex: 'wavi').listen(_notificationCallBack);
 
 void _notificationCallBack(AtNotification atNotification) {
     var notificationKey = atNotification.key;


### PR DESCRIPTION
Fixes #331 
**Additional context**
In the "Starting listening to notifications" section of the page, this 'using version 3.x' code snippet is incorrect
    `atClient!.notificationService.subscribe(regex: 'wavi').listen(_notificationCallBack);`
and it should read
    `atClientManager.notificationService.subscribe(regex: 'wavi').listen(_notificationCallBack);`