### PR TITLE
Add link-cards to Get Started page

### DIFF
--- a/content/en/docs/Get-Started/_index.md
+++ b/content/en/docs/Get-Started/_index.md
@@ -6,25 +6,10 @@ Description: "The fastest way to get started developing on the @platform"
 content: "Everything you need to get started developing on the @platform"
 weight: 1
 date: 2017-01-05
+notoc: true
+no_list: true
 ---
 
-<style>
-  .ItemCard{
-    width:200px;
-    height:150px;
-    border:1px solid #808080;
-  }
-
-  .row {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-  }
-
-  .Column {
-    flex: 1 1 0px;
-  }
-</style>
 
 The @platform was open-sourced in November of 2020 and we’ve been working hard to make your onboarding experience as smooth as possible ever since.
 
@@ -32,88 +17,11 @@ We’re excited to help you get your very own @platform environment up and runni
 
 We believe that the best way to get started with the platform is to actually try and experience it first hand.
 
-## If you are new here, we recommend the following path
+### If you are new here, we recommend the following path
+{{% card-grid %}}
+{{% link-card title="1. Try it out" desc="The fastest way to see the @platform in action!" href="/docs/get-started/tryatplatform/" %}}
+{{< link-card title="2. Learn the SDK" desc="A deep dive into the @platform and how to use the SDK." href="/docs/functional_architecture/" >}}
+{{% link-card title="3. Samples & Tutorials" desc="Check out some examples of the @platform in action!" href="/docs/sample_apps/" %}}#
+{{% link-card title="New to Flutter?" desc="Click here to learn more about it!" href="/docs/overview/newtoflutter" %}}
+{{% /card-grid %}}
 
-<div class="column">
-<div class="row">
-<a href="/docs/get-started/tryatplatform/">
-<div class="ItemCard">
-<center>
-<div  style="margin-top:15px;">
-<h5><b>Try the @platform</b></h5>
-</div>
-</center>
-<hr>
-<center>
-<div style="color:black;">
-Seeing the platform in action is the best way to understand it!
-</div>
-</center>
-</div>
-</a>
-
-<!-- Space between cards -->
-<div style="margin:10px;">
-</div>
-
-<a href="/docs/functional_architecture/">
-<div class="ItemCard">
-<center>
-<div  style="margin-top:15px;">
-<h5><b>Learn the SDK</b></h5>
-</div>
-</center>
-<hr>
-<center>
-<div style="color:black;">
-Interested in seeing what's behind the curtains?
-</div>
-</center>
-</div>
-</a>
-
-<!-- Space between cards -->
-<div style="margin:10px;">
-</div>
-
-<a href="/docs/sample_apps/">
-<div class="ItemCard">
-<center>
-<div  style="margin-top:15px;">
-<h5><b>Samples & Tutorials</b></h5>
-</div>
-</center>
-<hr>
-<center>
-<div style="color:black;">
-See some features and capabilities of the @platform!
-</div>
-</center>
-</div>
-</a>
-
-<!-- Space between cards -->
-<div style="margin:10px;">
-</div>
-<a href="/docs/overview/newtoflutter" target=_blank>
-<div class="ItemCard">
-<center>
-<div  style="margin-top:15px;">
-<h5><b>New to Flutter?</b></h5>
-</div>
-</center>
-<hr>
-<center>
-<div style="color:black;">
-Learn all about Flutter and have it installed on your machine!
-</div>
-</center>
-</div>
-</a>
-<!--Row div-->
-</div>
-
-<!--Column div-->
-</div>
-
-<!-- _To get started, follow through the guides listed below_ -->


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

See [at_docsy PR](https://github.com/atsign-foundation/at_docsy/pull/32).

Changed the get started page to use the new link-cards shortcode.

**- How I did it**

Local changes

**- How to verify it**



**- Description for the changelog**
Add link-cards to Get Started page
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->